### PR TITLE
CentOS 5 (Python 2.4) compatible import and changing from MIMEMultipart -> MIMEText

### DIFF
--- a/galeranotify.py
+++ b/galeranotify.py
@@ -15,7 +15,12 @@ import os
 import sys
 import getopt
 
-import smtplib, email
+import smtplib
+
+try: from email.mime.text import MIMEText
+except ImportError:
+    # Python 2.4 (CentOS 5.x)
+    from email.MIMEText import MIMEText
 
 import socket
 
@@ -93,14 +98,11 @@ def main(argv):
 
 def send_notification(from_email, to_email, subject, message, smtp_server,
                       smtp_port, use_ssl, use_auth, smtp_user, smtp_pass):
-    msg = email.MIMEMultipart.MIMEMultipart()
-    body = email.MIMEText.MIMEText(message)
+    msg = MIMEText(message)
 
-    msg.attach(body)
-
-    msg.add_header('From', from_email)
-    msg.add_header('To', ', '.join(to_email))
-    msg.add_header('Subject', subject)
+    msg['From'] = from_email
+    msg['To'] = ', '.join(to_email)
+    msg['Subject'] =  subject
 
     if(use_ssl):
         mailer = smtplib.SMTP_SSL(smtp_server, smtp_port)


### PR DESCRIPTION
Minor changes to make this compatible with CentOS 5 (RHEL 5) ancient Python 2.4. First I switched to MIMEText since it was a simple text message anyhow, MIMEMultipart would be to attach rich text, photos or other media. The name of the module changed slightly between Python versions.

Changes were based on a combination of:
- http://docs.python.org/2.4/lib/node597.html
- http://docs.python.org/2/library/email-examples.html
- http://stackoverflow.com/questions/342437/best-way-to-import-version-specific-python-modules

~tommy
